### PR TITLE
Use func location to grab source code

### DIFF
--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -320,6 +320,11 @@ let rec string_list_of_pat p = match p with
           l
   | _ -> debug_print "pat other"; []
 
+let extract_source_code l =
+   match Reporting.simp_loc l with
+   | Some(p1, p2) -> (Reporting.loc_range_to_src p1 p2)
+   | None -> "Error - couldn't locate func"
+
 let parse_funcl fcl = match fcl with
     FCL_aux ( FCL_funcl ( Id_aux (Id "execute", _), Pat_aux ( (
           Pat_exp ( P_aux ( P_app (i, pl), _ ) , e )
@@ -330,7 +335,7 @@ let parse_funcl fcl = match fcl with
         let operandl = (List.concat (List.map string_list_of_pat pl)) in
           if not (String.equal (List.hd operandl) "()") then
             Hashtbl.add operands (string_of_id i) operandl;
-        Hashtbl.add functions (string_of_id i) (string_of_exp e)
+        Hashtbl.add functions (string_of_id i) (extract_source_code (Ast_util.exp_loc e))
       end
   | _ -> debug_print "FCL_funcl other"
 


### PR DESCRIPTION
Fixes #3 

## Design
 `sail_doc_backend` (seems to be used by `asciidoctor-sail`) grabs the source code when creating the "Documentation Bundle" (`doc.json.`) I just stole some of that code.
 
## Create an example documentation bundle
If you are curious about the documentation bundle format. You can generate one:
```
make -C doc/asciidoc/
vim doc/asciidoc/sail_doc/exn.json
```


## Result
```
{
  "mnemonic": "addiw",
  "name": "Add Immediate Word",
  "operands": [
{
  "name": "imm", "type": "bits(12)"
}, 
{
  "name": "rs1", "type": "regidx"
}, 
{
  "name": "rd", "type": "regidx"
} ],
  "format": "I",
  "fields": [ { "field": "imm", "size": 12 }, { "field": "rs1", "size": 5 }, { "field": "0b000", "size": 3 }, { "field": "rd", "size": 5 },>
  "extensions": [  ],
  "function": "{\n  let result : xlenbits = sign_extend(imm) + X(rs1);\n  X(rd) = sign_extend(result[31..0]);\n  RETIRE_SUCCESS\n}",
  "description": "\nThe ADDIW instruction involves adding a sign-extended\n12-bit immediate value to the content of register rs1. The resul>
},
```