### PR TITLE
[JSON] Fix lingering comma after "functions"

### DIFF
--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -751,11 +751,15 @@ let defs { defs; _ } =
   print_endline "  ],";
 
   print_endline "  \"functions\": [";
-  Hashtbl.iter
-    (fun name source ->
-      print_endline ("  {\n    \"name\": \"" ^ name ^ "\",");
-      print_endline ("    \"source\": \"" ^ String.escaped source ^ "\"\n  },")
-    )
-    functions;
+  print_endline
+    (String.concat ",\n"
+       (Hashtbl.fold
+          (fun name source accum ->
+            ("  {\n    \"name\": \"" ^ name ^ "\",\n" ^ "    \"source\": \"" ^ String.escaped source ^ "\"\n  }")
+            :: accum
+          )
+          functions []
+       )
+    );
   print_endline "  ]";
   print_endline "}"


### PR DESCRIPTION
The tail end of the new "functions" content from
commit 4aa402457cc55b1e3b6fac20f18091aff0f5b1fc
has a lingering comma after the last element:
```
  {
    "name": "riscv_f32Div",
    "source": "{\n  [...]}"
  },
  ]
}
```

Fix this by using `String.concat` to join the "function" elements with a comma between them, instead of emitting each of them with a trailing comma.