### PR TITLE
Remove macos12 4.08.1 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,6 @@ jobs:
       matrix:
         version: [5.0.0]
         os: [ubuntu-latest, macOS-latest]
-        include:
-        - os: macos-12
-          version: 4.08.1
         exclude:
         - os: macos-latest
           version: 4.08.1


### PR DESCRIPTION
PR based on discussion [here](https://github.com/ThinkOpenly/sail/pull/35#issuecomment-2274264247)

Motivation: </br>
CI is failing with the error message :
``` 
#=== ERROR while compiling sail_json_backend.0.17 =============================#
# File "src/sail_json_backend/json.ml", line 97, characters 5-23:
# 97 |   if String.starts_with ~prefix:"\"" qs && String.ends_with ~suffix:"\"" qs then
#           ^^^^^^^^^^^^^^^^^^
# Error: Unbound value String.starts_with
```

The `macos-12 4.08.1` build fails but the `ubuntu-latest` and `macos-latest` builds do not fail. So it is better to remove the problematic build from the CI, because the latest versions work just fine. 

This error message is indicative of an outdated version of OCaml. Support in OCaml for String.starts_with arrived in OCaml 4.13, which was released almost 2 years ago (2021-09-24). This issue occurs on the "macos-12" target exclusively.
Since the work being done here is not platform-specific and is at the level of "proof-of-concept", disable the "macos-12" platform and move on.

cc @ThinkOpenly 