### PR TITLE
Update json_of_name to prioritize mnemonic over AST key

### DIFF
--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -673,8 +673,8 @@ let json_of_function k =
 
 let json_of_name k mnemonic =
   let name =
-    match Hashtbl.find_opt names k with
-    | None -> begin match Hashtbl.find_opt names mnemonic with None -> "TBD" | Some s -> String.escaped s end
+    match Hashtbl.find_opt names mnemonic with
+    | None -> begin match Hashtbl.find_opt names k with None -> "TBD" | Some s -> String.escaped s end
     | Some s -> String.escaped s
   in
   "\"" ^ name ^ "\""


### PR DESCRIPTION
This change ensures that when both AST and mnemonic are annoted for an instruction, the parser will prioritize the mnemonic as the key to retrieve the name from the Hashtbl. If the mnemonic is missing, the parser will fall back to using the AST as the default key.