### PR TITLE
Add mnemonic mapping for pseudoinstructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     - name: System dependencies (macOS)
       if: startsWith(matrix.os, 'macOS')
       run: |
-        brew install gpatch gmp z3 pkg-config lzlib zlib opam
+        brew install gpatch gmp z3 lzlib zlib opam
 
     - name: Restore cached opam
       id: cache-opam-restore

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -483,6 +483,18 @@ let parse_funcl fcl =
     end
   | _ -> debug_print "FCL_funcl other"
 
+let get_mnemonic id args_list = None
+
+let process_base_instruction () =
+  let mnemonics =
+    Hashtbl.fold
+      (fun k (id, args_list) acc ->
+        match get_mnemonic id args_list with Some mnemonic -> mnemonic :: acc | None -> acc
+      )
+      base_instructions []
+  in
+  mnemonics
+
 let json_of_key_operand key op t = "\n{\n" ^ "  \"name\": \"" ^ op ^ "\", \"type\": \"" ^ t ^ "\"\n" ^ "}"
 
 let json_of_mnemonic m = "\"" ^ m ^ "\""
@@ -832,6 +844,8 @@ let defs { defs; _ } =
       | _ -> debug_print ~printer:prerr_string ""
     )
     defs;
+
+  let mnemonics = process_base_instruction () in
 
   debug_print "TYPES";
   Hashtbl.iter (fun k v -> debug_print (k ^ ":" ^ v)) types;

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -504,9 +504,10 @@ let map_param_to_arg id param args_list =
   | None -> None
 
 let get_mnemonic id args_list =
+  let str_in_parens = Str.regexp ".+(\\(.*\\))" in
   match Hashtbl.find_opt assembly id with
   | Some (str :: _) ->
-      if Str.string_match (Str.regexp ".+(\\(.*\\))") str 0 then (
+      if Str.string_match str_in_parens str 0 then (
         let param = Str.matched_group 1 str in
         debug_print ("param: " ^ param);
         match map_param_to_arg id param args_list with Some arg -> map_arg_to_mnemonic arg id | None -> None

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -485,7 +485,8 @@ let parse_funcl fcl =
 
 let map_arg_to_mnemonic arg id = None
 
-let get_index elem lst = None
+let get_index elem lst =
+  List.find_map (fun (i, x) -> if x = elem then Some i else None) (List.mapi (fun i x -> (i, x)) lst)
 
 let map_param_to_arg id param args_list =
   match Hashtbl.find_opt inputs id with

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -493,8 +493,7 @@ let map_arg_to_mnemonic arg id =
     )
     (Hashtbl.find_all mappings (String.lowercase_ascii (id ^ "_mnemonic")))
 
-let get_index elem lst =
-  List.find_map (fun (i, x) -> if x = elem then Some i else None) (List.mapi (fun i x -> (i, x)) lst)
+let get_index elem lst = List.find_index (fun x -> x = elem) lst
 
 let map_param_to_arg id param args_list =
   match Hashtbl.find_opt inputs id with

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -435,8 +435,6 @@ let parse_funcl fcl =
           let source_code = extract_source_code (Ast_util.exp_loc e) in
           Hashtbl.add functions id source_code
       | Pat_exp (P_aux (P_app (i, pl), _), e) | Pat_when (P_aux (P_app (i, pl), _), e, _) -> (
-          debug_print ("FCL_funcl execute " ^ string_of_id i);
-          let source_code = extract_source_code (Ast_util.exp_loc e) in
           match id with
           | "pseudo_of" -> (
               debug_print ("FCL funcl pseudoinstruction " ^ string_of_id i);
@@ -451,8 +449,8 @@ let parse_funcl fcl =
                             (fun inner_exp ->
                               match inner_exp with
                               | E_aux (E_app (id_inner, el_inner), _) ->
-                                  List.iteri
-                                    (fun index inner_value ->
+                                  List.iter
+                                    (fun inner_value ->
                                       match inner_value with
                                       | E_aux (E_tuple tuple_list, _) ->
                                           let args_inner_list = List.map string_of_exp tuple_list in
@@ -475,6 +473,7 @@ let parse_funcl fcl =
               | _ -> ()
             )
           | "execute" | "pseudo_execute" ->
+              let source_code = extract_source_code (Ast_util.exp_loc e) in
               debug_print ("FCL_funcl execute " ^ string_of_id i);
               Hashtbl.add executes (string_of_id i) source_code
           | _ -> ()

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -483,7 +483,16 @@ let parse_funcl fcl =
     end
   | _ -> debug_print "FCL_funcl other"
 
-let map_arg_to_mnemonic arg id = None
+let map_arg_to_mnemonic arg id =
+  List.find_map
+    (fun (enum, mnemonic) ->
+      if List.hd enum = arg then (
+        debug_print ("Matched " ^ List.hd enum ^ " with mnemonic: " ^ List.hd mnemonic);
+        Some (List.hd mnemonic)
+      )
+      else None
+    )
+    (Hashtbl.find_all mappings (String.lowercase_ascii (id ^ "_mnemonic")))
 
 let get_index elem lst =
   List.find_map (fun (i, x) -> if x = elem then Some i else None) (List.mapi (fun i x -> (i, x)) lst)

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -517,11 +517,9 @@ let get_mnemonic id args_list =
         | Some (mnemonic :: _) when mnemonic = str ->
             debug_print ("Mnemonic matched: " ^ str);
             Some str
-        | Some _ -> None
-        | None -> None
+        | _ -> None
       )
-  | Some [] -> None
-  | None -> None
+  | _ -> None
 
 let process_base_instruction () =
   let mnemonics =

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -483,7 +483,28 @@ let parse_funcl fcl =
     end
   | _ -> debug_print "FCL_funcl other"
 
-let get_mnemonic id args_list = None
+let map_arg_to_mnemonic arg id = None
+
+let map_param_to_arg id param args_list = None
+
+let get_mnemonic id args_list =
+  match Hashtbl.find_opt assembly id with
+  | Some (str :: _) ->
+      if Str.string_match (Str.regexp ".+(\\(.*\\))") str 0 then (
+        let param = Str.matched_group 1 str in
+        debug_print ("param: " ^ param);
+        match map_param_to_arg id param args_list with Some arg -> map_arg_to_mnemonic arg id | None -> None
+      )
+      else (
+        match Hashtbl.find_opt assembly_clean id with
+        | Some (mnemonic :: _) when mnemonic = str ->
+            debug_print ("Mnemonic matched: " ^ str);
+            Some str
+        | Some _ -> None
+        | None -> None
+      )
+  | Some [] -> None
+  | None -> None
 
 let process_base_instruction () =
   let mnemonics =

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -482,16 +482,19 @@ let parse_funcl fcl =
     end
   | _ -> debug_print "FCL_funcl other"
 
-let map_arg_to_mnemonic arg id =
-  List.find_map
-    (fun (enum, mnemonic) ->
-      if List.hd enum = arg then (
-        debug_print ("Matched " ^ List.hd enum ^ " with mnemonic: " ^ List.hd mnemonic);
-        Some (List.hd mnemonic)
-      )
-      else None
+let map_arg_to_mnemonic arg =
+  Hashtbl.fold
+    (fun _ (enum, mnemonic) acc ->
+      match acc with
+      | Some _ -> acc
+      | None ->
+          if List.hd enum = arg then (
+            debug_print ("Matched " ^ List.hd enum ^ " with mnemonic: " ^ List.hd mnemonic);
+            Some (List.hd mnemonic)
+          )
+          else None
     )
-    (Hashtbl.find_all mappings (String.lowercase_ascii (id ^ "_mnemonic")))
+    mappings None
 
 let get_index elem lst = List.find_index (fun x -> x = elem) lst
 
@@ -509,7 +512,7 @@ let get_mnemonic id args_list =
       if Str.string_match str_in_parens str 0 then (
         let param = Str.matched_group 1 str in
         debug_print ("param: " ^ param);
-        match map_param_to_arg id param args_list with Some arg -> map_arg_to_mnemonic arg id | None -> None
+        match map_param_to_arg id param args_list with Some arg -> map_arg_to_mnemonic arg | None -> None
       )
       else (
         match Hashtbl.find_opt assembly_clean id with

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -485,7 +485,14 @@ let parse_funcl fcl =
 
 let map_arg_to_mnemonic arg id = None
 
-let map_param_to_arg id param args_list = None
+let get_index elem lst = None
+
+let map_param_to_arg id param args_list =
+  match Hashtbl.find_opt inputs id with
+  | Some inputl -> (
+      match get_index param inputl with Some index -> List.nth_opt args_list index | None -> None
+    )
+  | None -> None
 
 let get_mnemonic id args_list =
   match Hashtbl.find_opt assembly id with


### PR DESCRIPTION
This PR introduces functionality to retrieve the mnemonic for a base instruction associated with a pseudoinstruction.
This lays the groundwork for converting pseudoinstruction data into JSON. 

It includes the following key updates:

**Parse pseudoinstruction data**

Add functionality to parse AST data and store pseudoinstruction-to-base-instruction mappings in a Hashtable.
Example:
```
LA: [
  assembly(UTYPE(imm[31..12], rd, RISCV_AUIPC)),
  assembly(ITYPE(imm[11..0], reg_name("x0"), rd, RISCV_ADDI))
]
```
Stored as:
```
Adding to hashtable with key: LA, id_inner: UTYPE, args_inner_list: [subrange_bits(imm, 31, 12), rd, RISCV_AUIPC]
Adding to hashtable with key: LA, id_inner: ITYPE, args_inner_list: [subrange_bits(imm, 11, 0), reg_name_backwards("x0"), rd, RISCV_ADDI]
```

**Mnemonic retrieval (get_mnemonic)**
Add logic to extract a mnemonic by either direct extraction or mapping parameter to argument through `map_param_to_arg` and argument to mnemonic through `map_arg_to_mnemonic`.

Direct retrieval:
```
C_ZEXT_W: c.zext.w, creg_name(rsdc)
Returns: c.zext.w
```
param-arg-mnemonic:
```
ITYPE: itype_mnemonic(op), spc, reg_name(rd), sep, reg_name(rs1), sep, hex_bits_signed_12(imm)
Returns: op -> RISCV_ADDI -> addi
```
**Map parameter to argument (map_param_to_arg)**
Add function to match parameter with its corresponding argument in the parsed data.

Example:
```
Input list: ITYPE:  imm, rs1, rd, op
Argument list: [subrange_bits(imm, 11, 0), reg_name("x0"), rd, RISCV_ADDI]
Returns: RISCV_ADDI for op.
```

**Map mnemonic to argument (map_arg_to_mnemonic)**
Add function to match argument to its corresponding mnemonic using a predefined enum-mnemonic mapping.

Example:
```
Matched RISCV_AUIPC with mnemonic auipc.
Matched RISCV_ADDI with mnemonic addi.
```

These changes enable the `process_base_instruction` function to complete the first step of converting raw pseudoinstruction data into a JSON by retrieving mnemonics for all associated base instructions.