### PR TITLE
Fix Parsing Bugs in Instruction-Field Mapping

### DIFF
--- a/ocaml_debug.log
+++ b/ocaml_debug.log
@@ -1,0 +1,1 @@
+make: *** No rule to make target `json'.  Stop.

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -352,7 +352,6 @@ let handle_fmtencdec_mapping mc =
         | MP_aux (MP_app (type_id, _), _), MP_aux (MP_app (format_id, _), _) ->
             let instruction_type = string_of_id type_id in
             let format = string_of_id format_id in
-            debug_print ("Instruction type: " ^ instruction_type ^ ", format: " ^ format);
             Hashtbl.add instruction_type_to_format instruction_type format;
         | _ -> ()
       end
@@ -365,14 +364,14 @@ let parse_mapcl i mc =
     | MCL_aux (_, (annot, _)) ->
         String.concat "-"
           (List.map
-              (fun attr -> match attr with _, "format", Some (AD_aux (AD_string s, _)) -> s | _ -> "")
-              annot.attrs
+            (fun attr -> match attr with _, "format", Some (AD_aux (AD_string s, _)) -> s | _ -> "")
+            annot.attrs
           )
   in
   match string_of_id i with
   | "fmtencdec" ->
-    debug_print (string_of_id i);
-    handle_fmtencdec_mapping mc;
+      debug_print (string_of_id i);
+      handle_fmtencdec_mapping mc;
   | "encdec" | "encdec_compressed" ->
       debug_print (string_of_id i);
       parse_encdec i mc format;
@@ -754,7 +753,6 @@ let json_of_format k =
       )
   in
   "\"" ^ format ^ "\""
-  
 
 let json_of_extensions k = match Hashtbl.find_opt extensions k with None -> "" | Some l -> String.concat "," l
 
@@ -855,7 +853,7 @@ let defs { defs; _ } =
     (fun k v -> debug_print (k ^ ":" ^ Util.string_of_list ", " (fun (op, t) -> "(" ^ op ^ ", " ^ t ^ ")") v))
     operands;
   debug_print "ENCODINGS";
-  Hashtbl.iter (fun k v -> debug_print ("ENCODINGS DEBUG KEY:" ^ k ^ " VALUE :" ^ Util.string_of_list ", " (fun x -> x) v)) encodings;
+  Hashtbl.iter (fun k v -> debug_print (k ^ ":" ^ Util.string_of_list ", " (fun x -> x) v)) encodings;
   debug_print "ASSEMBLY";
   Hashtbl.iter (fun k v -> debug_print (k ^ ":" ^ Util.string_of_list ", " (fun x -> x) v)) assembly;
   debug_print "EXECUTES";
@@ -870,7 +868,7 @@ let defs { defs; _ } =
   Hashtbl.iter (fun k v -> debug_print (k ^ ":" ^ v)) formats;
   debug_print "MAPPINGS";
   Hashtbl.iter
-    (fun k v -> match v with l, r -> debug_print ("MAPPINGS DEBUG KEY:" ^ k ^ " VALUE: " ^ String.concat "," l ^ " <-> " ^ String.concat "," r))
+    (fun k v -> match v with l, r -> debug_print (k ^ ":" ^ String.concat "," l ^ " <-> " ^ String.concat "," r))
     mappings;
   debug_print "TYPE_TO_MNEMONIC_MAP";
   Hashtbl.iter (fun k v -> debug_print("TTMP DEBUG KEY: " ^ k ^ " value: " ^ v)) type_to_mnemonic_map;
@@ -899,8 +897,6 @@ let defs { defs; _ } =
     (String.concat ",\n" (List.map (fun a ->
         let key = List.hd a in
         let value = List.tl a in
-        debug_print ("SORTED Key: " ^ key);
-        debug_print ("Value: " ^ String.concat ", " value);
         json_of_instruction key value
     ) key_mnemonic_sorted));  
 
@@ -929,13 +925,13 @@ let defs { defs; _ } =
   print_endline "  \"functions\": [";
   print_endline
     (String.concat ",\n"
-       (Hashtbl.fold
-          (fun name source accum ->
-            ("  {\n    \"name\": \"" ^ name ^ "\",\n" ^ "    \"source\": \"" ^ String.escaped source ^ "\"\n  }")
-            :: accum
-          )
-          functions []
-       )
+      (Hashtbl.fold
+        (fun name source accum ->
+          ("  {\n    \"name\": \"" ^ name ^ "\",\n" ^ "    \"source\": \"" ^ String.escaped source ^ "\"\n  }")
+          :: accum
+        )
+        functions []
+      )
     );
   print_endline "  ]";
   print_endline "}"

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -184,18 +184,27 @@ let parse_encdec_mpat mp pb format =
       debug_print ("MP_app " ^ string_of_id app_id);
       Hashtbl.add formats (string_of_id app_id) format;
       let operandl = List.concat (List.map string_list_of_mpat mpl) in
+      List.iter debug_print operandl;
+      debug_print "MCL_bidir (right part)";
       begin
-        List.iter debug_print operandl;
-        debug_print "MCL_bidir (right part)";
-        match pb with
-        | MPat_aux (MPat_pat p, _) ->
-            debug_print "MPat_pat ";
-            List.iter debug_print (string_list_of_mpat p);
-            Hashtbl.add encodings (string_of_id app_id) (string_list_of_mpat p)
-        | MPat_aux (MPat_when (p, e), _) ->
-            debug_print "MPat_when ";
-            List.iter debug_print (string_list_of_mpat p);
-            Hashtbl.add encodings (string_of_id app_id) (string_list_of_mpat p)
+        match List.rev mpl with
+        | mp_last :: _ ->
+          begin match mp_last with
+          | MP_aux (MP_id id, _) ->
+            begin
+              match pb with
+              | MPat_aux (MPat_pat p, _) ->
+                  debug_print "MPat_pat ";
+                  List.iter debug_print (string_list_of_mpat p);
+                  Hashtbl.add encodings (string_of_id id) (string_list_of_mpat p)
+              | MPat_aux (MPat_when (p, e), _) ->
+                  debug_print "MPat_when ";
+                  List.iter debug_print (string_list_of_mpat p);
+                  Hashtbl.add encodings (string_of_id id) (string_list_of_mpat p)
+            end
+          | _ -> ()
+          end
+        | [] -> ()
       end;
       string_of_id app_id
   | _ -> assert false

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -198,8 +198,6 @@ let parse_encdec_mpat mp pb format =
       end;
       string_of_id app_id
   | _ -> assert false
-  
-  
 
 (* This looks for any "extension(string)", and does not, for example
    account for negation. This case should be pretty unlikely, however. *)
@@ -318,37 +316,33 @@ let parse_assembly i mc =
       end
   | _ -> assert false
 
+let handle_fmtencdec_mapping mc =
+  debug_print "handle_fmtencdec_mapping called";
+  match mc with
+  | MCL_aux (MCL_bidir (lhs_mpexp, rhs_mpexp), _) ->
+      begin
+        let lhs_pat = match lhs_mpexp with
+          | MPat_aux (MPat_pat pat, _) -> pat
+          | MPat_aux (MPat_when (pat, _), _) -> pat
+        in
+        let rhs_pat = match rhs_mpexp with
+          | MPat_aux (MPat_pat pat, _) -> pat
+          | MPat_aux (MPat_when (pat, _), _) -> pat
+        in
+        match lhs_pat, rhs_pat with
+        | MP_aux (MP_app (type_id, _), _), MP_aux (MP_app (format_id, _), _) ->
+            let instruction_type = string_of_id type_id in
+            let format = string_of_id format_id in
+            debug_print ("Instruction type: " ^ instruction_type ^ ", format: " ^ format);
+            Hashtbl.add instruction_type_to_format instruction_type format;
+        | _ -> ()
+      end
+  | _ -> debug_print "Not an fmtencdec mapping"
+
 let parse_mapcl i mc =
   debug_print ("parse_mapcl " ^ string_of_id i);
 
-  let handle_fmtencdec_mapping mc =
-    debug_print "handle_fmtencdec_mapping called";
-    match mc with
-    | MCL_aux (MCL_bidir (lhs_mpexp, rhs_mpexp), _) ->
-        begin
-          let lhs_pat = match lhs_mpexp with
-            | MPat_aux (MPat_pat pat, _) -> pat
-            | MPat_aux (MPat_when (pat, _), _) -> pat
-          in
-          let rhs_pat = match rhs_mpexp with
-            | MPat_aux (MPat_pat pat, _) -> pat
-            | MPat_aux (MPat_when (pat, _), _) -> pat
-          in
-          match lhs_pat, rhs_pat with
-          | MP_aux (MP_app (type_id, _), _), MP_aux (MP_app (format_id, _), _) ->
-              let instruction_type = string_of_id type_id in
-              let format = string_of_id format_id in
-              debug_print ("Instruction type: " ^ instruction_type ^ ", format: " ^ format);
-              Hashtbl.add instruction_type_to_format instruction_type format;
-          | _ -> debug_print "Unhandled pattern in fmtencdec mapping"
-        end
-    | _ -> debug_print "Not an fmtencdec mapping"
-  in
-
   match string_of_id i with
-  | "fmtencdec" ->
-      debug_print ("Handling fmtencdec for " ^ string_of_id i);
-      handle_fmtencdec_mapping mc;
   | "encdec" | "encdec_compressed" ->
       debug_print ("Handling encdec for " ^ string_of_id i);
       let format = "" in
@@ -448,65 +442,21 @@ let extract_source_code l =
   | Some (p1, p2) -> Reporting.loc_range_to_src p1 p2
   | None -> "Error - couldn't locate func"
 
-(* parse_funcl did not help in mapping formats. It was done in parse_mapcl.
-   However, debug statement might be useful for future works.
-*)
 let parse_funcl fcl =
   match fcl with
   | FCL_aux (FCL_funcl (Id_aux (Id id, _), Pat_aux (pat, _)), _) -> begin
       match pat with
       | Pat_exp (P_aux (P_tuple pl, _), e) | Pat_when (P_aux (P_tuple pl, _), e, _) ->
-          debug_print ("parse_funcl id_of_dependent: " ^ id);
+          debug_print ("id_of_dependent: " ^ id);
           let source_code = extract_source_code (Ast_util.exp_loc e) in
           Hashtbl.add functions id source_code
       | Pat_exp (P_aux (P_app (i, pl), _), e) | Pat_when (P_aux (P_app (i, pl), _), e, _) ->
-          debug_print ("parse_funcl FCL_funcl execute " ^ id);
+          debug_print ("FCL_funcl execute " ^ string_of_id i);
           let source_code = extract_source_code (Ast_util.exp_loc e) in
-          ()
-      | Pat_exp (P_aux (P_lit my_literal, _), e) | Pat_when (P_aux (P_lit my_literal, _), e, _) ->
-        (* This mapping is kinda unnecessary, depend on future tasks *)
-        if id = "opcode2format" then
-          debug_print ("parse_funcl Mapped opcode " ^ opcode ^ " to format " ^ format);
-        else
-          debug_print ("parse_funcl " ^ id ^ ": " ^ string_of_lit my_literal ^ "exp: " ^ string_of_exp e);
-      | Pat_exp (P_aux (P_wild, _), e) | Pat_when (P_aux (P_wild, _), e, _) ->
-          debug_print ("parse_funcl Wildcard pattern in " ^ id);
-          ()
-      | Pat_exp (P_aux (P_typ (typ, p), _), e) | Pat_when (P_aux (P_typ (typ, p), _), e, _) ->
-          debug_print ("parse_funcl Typed pattern in " ^ id);
-          ()
-      | Pat_exp (P_aux (P_id ident, _), e) | Pat_when (P_aux (P_id ident, _), e, _) ->
-          debug_print ("parse_funcl Identifier pattern: " ^ string_of_id ident);
-          ()
-      | Pat_exp (P_aux (P_var (p, typ), _), e) | Pat_when (P_aux (P_var (p, typ), _), e, _) ->
-          debug_print ("parse_funcl Pattern variable in " ^ id);
-          ()
-      | Pat_exp (P_aux (P_vector pl, _), e) | Pat_when (P_aux (P_vector pl, _), e, _) ->
-          debug_print ("parse_funcl Vector pattern in " ^ id);
-          ()
-      | Pat_exp (P_aux (P_vector_concat pl, _), e) | Pat_when (P_aux (P_vector_concat pl, _), e, _) ->
-          debug_print ("parse_funcl Concatenated vector pattern in " ^ id);
-          ()
-      | Pat_exp (P_aux (P_vector_subrange (ident, start_idx, end_idx), _), e)
-      | Pat_when (P_aux (P_vector_subrange (ident, start_idx, end_idx), _), e, _) ->
-          debug_print ("parse_funcl Vector subrange pattern in " ^ id ^ " from " ^ Z.to_string start_idx ^ " to " ^ Z.to_string end_idx);
-          ()
-      | Pat_exp (P_aux (P_list pl, _), e) | Pat_when (P_aux (P_list pl, _), e, _) ->
-          debug_print ("parse_funcl List pattern in " ^ id);
-          ()
-      | Pat_exp (P_aux (P_cons (p1, p2), _), e) | Pat_when (P_aux (P_cons (p1, p2), _), e, _) ->
-          debug_print ("parse_funcl Cons pattern in " ^ id);
-          ()
-      | Pat_exp (P_aux (P_string_append pl, _), e) | Pat_when (P_aux (P_string_append pl, _), e, _) ->
-          debug_print ("parse_funcl String append pattern in " ^ id);
-          ()
-      | Pat_exp (P_aux (P_struct (fl, typ), _), e) | Pat_when (P_aux (P_struct (fl, typ), _), e, _) ->
-          debug_print ("parse_funcl Struct pattern in " ^ id);
-          ()
-      | _ -> debug_print ("Other pattern in " ^ id)
+          Hashtbl.add executes (string_of_id i) source_code
+      | _ -> ()
     end
   | _ -> debug_print "FCL_funcl other"
-
 
 let json_of_key_operand key op t = "\n{\n" ^ "  \"name\": \"" ^ op ^ "\", \"type\": \"" ^ t ^ "\"\n" ^ "}"
 
@@ -748,9 +698,7 @@ let json_of_description k =
   let description = match Hashtbl.find_opt descriptions k with None -> "TBD" | Some f -> String.escaped f in
   "\"" ^ description ^ "\""
 
-
 let json_of_format k =
-  (* Debug message to print the value of k *)
   debug_print ("K is " ^ k);
   
   let format =
@@ -774,7 +722,6 @@ let json_of_instruction k v =
   ^ "  \"format\": " ^ json_of_format k ^ ",\n" ^ "  \"fields\": [ " ^ json_of_fields k ^ " ],\n"
   ^ "  \"extensions\": [ " ^ json_of_extensions k ^ " ],\n" ^ "  \"function\": " ^ json_of_function k ^ ",\n"
   ^ "  \"description\": " ^ json_of_description k ^ "\n" ^ "}"
-  
 
 let rec parse_typ name t =
   match t with
@@ -828,7 +775,6 @@ let rec explode_mnemonics asm =
     end
     else explode_mnemonic [([""], [List.hd asm])] tails
   )
-
 
 let defs { defs; _ } =
   List.iter

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -341,14 +341,24 @@ let handle_fmtencdec_mapping mc =
 
 let parse_mapcl i mc =
   debug_print ("parse_mapcl " ^ string_of_id i);
-
+  let format =
+    match mc with
+    | MCL_aux (_, (annot, _)) ->
+        String.concat "-"
+          (List.map
+              (fun attr -> match attr with _, "format", Some (AD_aux (AD_string s, _)) -> s | _ -> "")
+              annot.attrs
+          )
+  in
   match string_of_id i with
+  | "fmtencdec" ->
+    debug_print (string_of_id i);
+    handle_fmtencdec_mapping mc;
   | "encdec" | "encdec_compressed" ->
-      debug_print ("Handling encdec for " ^ string_of_id i);
-      let format = "" in
+      debug_print (string_of_id i);
       parse_encdec i mc format;
   | "assembly" ->
-      debug_print ("Handling assembly for " ^ string_of_id i);
+      debug_print (string_of_id i);
       parse_assembly i mc;
   | _ -> begin
       match mc with
@@ -699,8 +709,6 @@ let json_of_description k =
   "\"" ^ description ^ "\""
 
 let json_of_format k =
-  debug_print ("K is " ^ k);
-  
   let format =
     match Hashtbl.find_opt instruction_type_to_format k with
     | None -> "TBD"

--- a/src/sail_json_backend/json.ml
+++ b/src/sail_json_backend/json.ml
@@ -346,14 +346,14 @@ let parse_mapcl i mc =
     | MCL_aux (_, (annot, _)) ->
         String.concat "-"
           (List.map
-              (fun attr -> match attr with _, "format", Some (AD_aux (AD_string s, _)) -> s | _ -> "")
-              annot.attrs
+            (fun attr -> match attr with _, "format", Some (AD_aux (AD_string s, _)) -> s | _ -> "")
+            annot.attrs
           )
   in
   match string_of_id i with
   | "fmtencdec" ->
-    debug_print (string_of_id i);
-    handle_fmtencdec_mapping mc;
+      debug_print (string_of_id i);
+      handle_fmtencdec_mapping mc;
   | "encdec" | "encdec_compressed" ->
       debug_print (string_of_id i);
       parse_encdec i mc format;
@@ -717,7 +717,6 @@ let json_of_format k =
       )
   in
   "\"" ^ format ^ "\""
-  
 
 let json_of_extensions k = match Hashtbl.find_opt extensions k with None -> "" | Some l -> String.concat "," l
 


### PR DESCRIPTION
### **Added new data structure:**
`type_to_mnemonic_map hashtable.`

### **Parsing Changes**
In `parse_mapcl`, when adding key-value pairs to the `mappings` hashtable, we perform an additional check. If the key of the mapping ends with “mnemonic,” we parse the value of the mapping (left and right) to populate the `type_to_mnemonic_map` hashtable.

For example, the parsed `type_to_mnemonic_map` might look like this:

> KEY: RISCV_ADD value: add
> KEY: VXCMP_VMSGTU value: vmsgtu.vx
> KEY: VX_VXOR value: vxor.vx
> KEY: VX_VSADDU value: vsaddu.vx
> KEY: FNV_CVT_F_F value: vfncvt.f.f.w
> KEY: FVV_VNMSAC value: vfnmsac.vv

In `parse_encdec_mpat`, we construct the `key_string` used to store entries in the `encodings` hashtable as follows:

- If the `app_id` exists in `type_to_mnemonic_map`, we use its corresponding mnemonic as the `key_string`.
- If the `id` exists in` type_to_mnemonic_map`, we use its mnemonic as the `key_string`.
- Otherwise, we construct a fallback `key_string` in the format `app_id-id`

### **Example 1 (Success):**
`mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_ADD) <-> 0b0000000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011  `

We check for keys RTYPE and RISCV_ADD in the type_to_mnemonic_map. In this example, RISCV_ADD is found, mapping to the mnemonic add. We then store this mnemonic (add) as the key_string in the encodings hashtable, along with the corresponding pattern extracted from the clause.

json output:

> {
>   "mnemonic": "add",
>   "name": "add",
>   "operands": [ { "name": "rd", "type": "regidx", "optional": false },{ "name": "rs1", "type": "regidx", "optional": false },{ "name": "rs2", "type": "regidx", "optional": false } ],
>   "syntax": "rd,rs1,rs2",
>   "format": "TBD",
>   "fields": [ { "field": "0b0000000", "size": 7 }, { "field": "rs2", "size": 5 }, { "field": "rs1", "size": 5 }, { "field": "0b000", "size": 3 }, { "field": "rd", "size": 5 }, { "field": "0b0110011", "size": 7 } ],
>   "extensions": [  ],
>   "function": "{\n  let rs1_val = X(rs1);\n  let rs2_val = X(rs2);\n  let result : xlenbits = match op {\n    RISCV_ADD  => rs1_val + rs2_val,\n    RISCV_SLT  => zero_extend(bool_to_bits(rs1_val <_s rs2_val)),\n    RISCV_SLTU => zero_extend(bool_to_bits(rs1_val <_u rs2_val)),\n    RISCV_AND  => rs1_val & rs2_val,\n    RISCV_OR   => rs1_val | rs2_val,\n    RISCV_XOR  => rs1_val ^ rs2_val,\n    RISCV_SLL  => if   sizeof(xlen) == 32\n                  then rs1_val << (rs2_val[4..0])\n                  else rs1_val << (rs2_val[5..0]),\n    RISCV_SRL  => if   sizeof(xlen) == 32\n                  then rs1_val >> (rs2_val[4..0])\n                  else rs1_val >> (rs2_val[5..0]),\n    RISCV_SUB  => rs1_val - rs2_val,\n    RISCV_SRA  => if   sizeof(xlen) == 32\n                  then shift_right_arith32(rs1_val, rs2_val[4..0])\n                  else shift_right_arith64(rs1_val, rs2_val[5..0])\n  };\n  X(rd) = result;\n  RETIRE_SUCCESS\n}",
>   "description": "\nThe R-type (Register-type) instruction format is used for operations\nthat involve three registers. The specific operation is determined\nby the opcode and funct7 fields. The result is written to the\ndestination register (rd), and the source operands are specified\nby the source registers (rs1 and rs2). The format is common for\narithmetic, logical, and shift operations.\n "
> },

### **Example 2 (Failed):**
```
union clause ast = ITYPE : (bits(12), regidx, regidx, iop)

mapping encdec_iop : iop <-> bits(3) = {
  RISCV_ADDI  <-> 0b000,
  RISCV_SLTI  <-> 0b010,
  RISCV_SLTIU <-> 0b011,
  RISCV_ANDI  <-> 0b111,
  RISCV_ORI   <-> 0b110,
  RISCV_XORI  <-> 0b100
}
```

In this case, the app_id is ITYPE and the id is iop. Since neither ITYPE nor iop exist in the type_to_mnemonic_map, we fall back to constructing the key_string as ITYPE-iop and store it in the encodings hashtable under this fallback key.

json output:

> {
>   "mnemonic": "addi",
>   "name": "add immediate",
>   "operands": [ { "name": "rd", "type": "regidx", "optional": false },{ "name": "rs1", "type": "regidx", "optional": false },{ "name": "imm", "type": "bits(12)", "optional": false } ],
>   "syntax": "rd,rs1,imm",
>   "format": "TBD",
>   "fields": [  ],
>   "extensions": [  ],
>   "function": "{\n  let rs1_val = X(rs1);\n  let immext : xlenbits = sign_extend(imm);\n  let result : xlenbits = match op {\n    RISCV_ADDI  => rs1_val + immext,\n    RISCV_SLTI  => zero_extend(bool_to_bits(rs1_val <_s immext)),\n    RISCV_SLTIU => zero_extend(bool_to_bits(rs1_val <_u immext)),\n    RISCV_ANDI  => rs1_val & immext,\n    RISCV_ORI   => rs1_val | immext,\n    RISCV_XORI  => rs1_val ^ immext\n  };\n  X(rd) = result;\n  RETIRE_SUCCESS\n}",
>   "description": "\nThe ITYPE instruction operates on an immediate value, adding, comparing, or\nperforming bitwise operations with the contents of register rs1.\nThe immediate value, rs1, and the operation code (iop) determine the operation.\nThe result is stored in register rd.\nThe supported immediate operations (iop) include:\n  - \"addi\"  : Add immediate\n  - \"slti\"  : Set less than immediate (signed)\n  - \"sltiu\" : Set less than immediate (unsigned)\n  - \"andi\"  : AND immediate\n  - \"ori\"   : OR immediate\n  - \"xori\"  : XOR immediate\n\nNote: The immediate value is sign-extended before performing the operation.\n "
> },